### PR TITLE
Replace fabs calls with qAbs to avoid compile errors

### DIFF
--- a/src/symbol/symbol_pin.cpp
+++ b/src/symbol/symbol_pin.cpp
@@ -64,7 +64,7 @@ void ASymbolPin::setLength(double length)
     //TODO - apply inverse action
 
     //TODO better logic here (min / max length, etc)
-    length_ = fabs(length);
+    length_ = qAbs(length);
 
     prepareGeometryChange();
 }

--- a/src/tools/rect_drawing_tool.cpp
+++ b/src/tools/rect_drawing_tool.cpp
@@ -59,7 +59,7 @@ QRectF RectDrawingTool::getRect()
     // Enforce a square
     if (mods & Qt::ControlModifier)
     {
-        double dim = qMax(fabs(x), fabs(y));
+        double dim = qMax(qAbs(x), qAbs(y));
         x = dim * (x > 0 ? 1 : -1);
         y = dim * (y > 0 ? 1 : -1);
     }


### PR DESCRIPTION
The compile was erroring out on my system, QT has a generic abs function, qAbs, I already used it in the code for the selection window.